### PR TITLE
add btn to password input for signup page

### DIFF
--- a/src/pages/signup.js
+++ b/src/pages/signup.js
@@ -5,8 +5,10 @@ import AuthLayout from '../components/layouts/auth-layout';
 import Button from '../components/atoms/button';
 
 function SignUp() {
-	const auth = useAuth();
 	const [error, setError] = useState(null);
+	const [showPassword, setShowPassword] = useState(false);
+
+	const auth = useAuth();
 
 	const handleSubmit = async (event) => {
 		setError(null);
@@ -22,6 +24,10 @@ function SignUp() {
 		}
 	};
 
+	const getTypeOfPassword = () => {
+		return showPassword ? 'text' : 'password';
+	};
+
 	return (
 		<AuthLayout>
 			<form onSubmit={handleSubmit}>
@@ -33,7 +39,44 @@ function SignUp() {
 
 					<div className="m-2 sm:m-1 xsm:m-1 flex flex-col">
 						<label className="py-2">Password:</label>
-						<input className="py-2 px-3 xsm:w-48 sm:w-60 w-80 border-2 border-black" name="password" type="password" />
+						<div className="border-2 border-black w-80 relative">
+							<input type={getTypeOfPassword()} className="py-2 px-3 outline-none w-full" name="password" />
+							<label onClick={() => setShowPassword(!showPassword)} className="absolute right-3 top-2 cursor-pointer">
+								{showPassword && (
+									<svg
+										className="w-6 h-6"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										xmlns="http://www.w3.org/2000/svg">
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth="2"
+											d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth="2"
+											d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"></path>
+									</svg>
+								)}
+								{!showPassword && (
+									<svg
+										className="w-6 h-6"
+										fill="none"
+										stroke="currentColor"
+										viewBox="0 0 24 24"
+										xmlns="http://www.w3.org/2000/svg">
+										<path
+											strokeLinecap="round"
+											strokeLinejoin="round"
+											strokeWidth="2"
+											d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"></path>
+									</svg>
+								)}
+							</label>
+						</div>
 					</div>
 
 					<Button


### PR DESCRIPTION
# Description
This pr add show hide button to input password in signup page

## Related issues
Fixes [#135](https://quire.io/w/Caspian_Tamin/135/show_hide_btn_for_other_password_input?view=tree)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
1. go to login page
2. click on (Dont have an account yet?) link and redirect ro signup page
3. see show hide button near input password

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules